### PR TITLE
Redesign detail screen.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,9 @@ dependencies {
     // WorkManager
     implementation(libs.androidx.work)
 
+    // CCT (browser)
+    implementation(libs.browser)
+
     // Android
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/mapper/ArticleMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/mapper/ArticleMapper.kt
@@ -14,6 +14,7 @@ internal fun ArticleEntity.toDomain(): ArticleDetail {
         imageUrl = imageUrl,
         url = url,
         authors = author,
-        publishedAt = date
+        publishedAt = date,
+        newsSite = newsSite
     )
 }

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/model/ArticleEntity.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/model/ArticleEntity.kt
@@ -24,7 +24,8 @@ internal data class ArticleEntity(
     val url: String,
     val imageUrl: String,
     val author: List<String>,
-    val date: String
+    val date: String,
+    val newsSite: String,
 )
 
 private const val TABLE_NAME = "articles"

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/mapper/ArticleResponseMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/mapper/ArticleResponseMapper.kt
@@ -14,6 +14,7 @@ internal fun ArticleResponse.toEntity(): ArticleEntity {
         url = url,
         summary = summary,
         author = authors.map { it.name },
-        date = publishedAt
+        date = publishedAt,
+        newsSite = newsSite
     )
 }

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/network/mapper/ArticleDetailMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/network/mapper/ArticleDetailMapper.kt
@@ -14,6 +14,7 @@ internal fun ArticleResponse.toDomain(): ArticleDetail {
         imageUrl = imageUrl,
         url = url,
         authors = authors.map { it.name }, // Extracts only author names
-        publishedAt = publishedAt
+        publishedAt = publishedAt,
+        newsSite = newsSite
     )
 }

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/network/model/ArticleResponse.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/network/model/ArticleResponse.kt
@@ -33,7 +33,10 @@ internal data class ArticleResponse(
     val authors: List<Author>,
 
     @SerializedName("published_at")
-    val publishedAt: String
+    val publishedAt: String,
+
+    @SerializedName("news_site")
+    val newsSite: String,
 )
 
 /**
@@ -43,5 +46,5 @@ internal data class ArticleResponse(
  */
 internal data class Author(
     @SerializedName("name")
-    val name: String
+    val name: String,
 )

--- a/app/src/main/java/com/kurnavova/spacedout/domain/model/ArticleDetail.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/model/ArticleDetail.kt
@@ -10,6 +10,7 @@ package com.kurnavova.spacedout.domain.model
  * @property url The URL of the article.
  * @property authors The authors of the article.
  * @property publishedAt The date the article was published.
+ * @property newsSite The name of the news site.
  */
 data class ArticleDetail(
     val id: Int,
@@ -18,5 +19,6 @@ data class ArticleDetail(
     val imageUrl: String,
     val url: String,
     val authors: List<String>,
-    val publishedAt: String
+    val publishedAt: String,
+    val newsSite: String,
 )

--- a/app/src/main/java/com/kurnavova/spacedout/domain/usecase/mapper/ArticleMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/usecase/mapper/ArticleMapper.kt
@@ -18,7 +18,8 @@ internal fun ArticleDetail.toArticle(): Article = Article(
     imageUrl = imageUrl,
     url = url,
     authors = authors.joinToString(", "), // For simplicity, let's do this here (should be done in ui layer thought)
-    publishedAt = formatDateTime(publishedAt)
+    publishedAt = formatDateTime(publishedAt),
+    newsSite = newsSite
 )
 
 private fun formatDateTime(isoDateTime: String, locale: Locale = Locale.getDefault()): String {

--- a/app/src/main/java/com/kurnavova/spacedout/domain/usecase/model/Article.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/usecase/model/Article.kt
@@ -11,4 +11,5 @@ data class Article(
     val url: String,
     val authors: String,
     val publishedAt: String,
+    val newsSite: String,
 )

--- a/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/NewsDetailScreen.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/NewsDetailScreen.kt
@@ -83,7 +83,8 @@ private fun NewsDetailScreenPreview() {
                     imageUrl = "https://www.nasa.gov/wp-content/uploads/2025/03/lrc-2025-ocio-p-00643-3.jpg",
                     url = "http://example.com",
                     authors = "Author 1, Author 2",
-                    publishedAt = "02/03/1992"
+                    publishedAt = "02/03/1992",
+                    newsSite = "NASA"
                 )
             )
         )

--- a/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/components/ArticleDetail.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/components/ArticleDetail.kt
@@ -1,5 +1,6 @@
 package com.kurnavova.spacedout.features.newsdetail.ui.components
 
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kurnavova.spacedout.R
@@ -23,7 +25,7 @@ import com.kurnavova.spacedout.ui.components.text.ClickableText
 import com.kurnavova.spacedout.ui.components.text.HighlightedText
 import com.kurnavova.spacedout.ui.components.text.FadedSubtitle
 import com.kurnavova.spacedout.ui.theme.SpacedOutTheme
-import com.kurnavova.spacedout.ui.utils.IntentUtils
+import androidx.core.net.toUri
 
 @Composable
 fun ArticleDetail(
@@ -69,13 +71,26 @@ fun ArticleDetail(
 
         ClickableText(
             text = stringResource(R.string.news_detail_read_article_here),
-            onClick = { IntentUtils.openBrowser(article.url, context) },
+            onClick = {
+                val customTabsIntent = CustomTabsIntent.Builder().build()
+                customTabsIntent.launchUrl(context, article.url.toUri())
+            },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+
+        Spacer(modifier = Modifier.height(SPACE_UNDER_BUTTON.dp))
+
+        Text(
+            text = stringResource(R.string.news_site_label, article.newsSite),
+            style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.primary,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
     }
 }
 
 private const val SPACE_BETWEEN_ITEMS = 16
+private const val SPACE_UNDER_BUTTON = 8
 private const val AUTHOR_PADDING = 8
 private const val IMAGE_PADDING = 8
 
@@ -91,7 +106,8 @@ private fun ArticleDetailPreview() {
                 imageUrl = "https://example.com/image.jpg",
                 authors = "Author",
                 publishedAt = "2022-01-01",
-                url = "https://example.com"
+                url = "https://example.com",
+                newsSite = "NASA"
             )
         )
     }

--- a/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/NewsListScreen.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/NewsListScreen.kt
@@ -132,7 +132,8 @@ private fun NewsListPreview() {
         imageUrl = "https://example.com/image.jpg",
         url = "https://example.com",
         authors = "Author 1, Author 2",
-        publishedAt = "02/03/1992"
+        publishedAt = "02/03/1992",
+        newsSite = "NASA"
     )
 
     val articles = flow {

--- a/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/components/ListArticle.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/components/ListArticle.kt
@@ -47,7 +47,8 @@ private fun ListArticlePreview() {
                 imageUrl = "https://www.nasa.gov/wp-content/uploads/2025/03/lrc-2025-ocio-p-00643-3.jpg",
                 url = "http://example.com",
                 authors = "Author 1, Author 2",
-                publishedAt = "02/03/1992"
+                publishedAt = "02/03/1992",
+                newsSite = "NASA"
             ),
             showDivider = true,
             showDetail = {}

--- a/app/src/main/java/com/kurnavova/spacedout/ui/components/card/AlertBanner.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/ui/components/card/AlertBanner.kt
@@ -52,7 +52,6 @@ fun AlertBanner(
                 )
             }
         }
-
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="news_detail_read_article_here">Read the whole article here</string>
     <!-- Authors and date time of the news article. %1$s will be replaced by list of authors and %2$s by date and time of article. -->
     <string name="news_detail_authors_datetime">%1$s, %2$s</string>
+    <!-- News site, where %1$s will be replaced by actual news site. -->
+    <string name="news_site_label">News site: %1$s</string>
 
     <!-- News list screen -->
     <!-- Read more - clickable text button leading to article detail. -->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ paging = "3.3.6"
 ksp = "2.1.20-RC-1.0.30"
 work = "2.10.0"
 kotlinxCoroutinesTest = "1.9.0"
+cct = "1.5.0"
 
 [libraries]
 koin = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
@@ -40,6 +41,7 @@ kotlin-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlin
 kotlinx-serialization = {group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization"}
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+browser = { module = "androidx.browser:browser", version.ref = "cct" }
 
 paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "paging" }
 paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }


### PR DESCRIPTION
- Add CCT for opening links
- Add News site information

Prompts used for ChatGPT:

_Change behaviour of ClickableText::onClick in this component so that it leads to CCT in-app web using the article.url. Give me code for onClick method, dependencies needed in catalog format, configuration and logic for CCT._

_Add new text displaying article.newsSite, centered right under the ClickableText. It will be part of the string "News site: $article.newsSite" - give me string definition with comment about its usage. The text will have primary bold color, and be bodySmall_