### PR TITLE
Add favourites feature.

### DIFF
--- a/app/src/main/java/com/kurnavova/spacedout/App.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/App.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.kurnavova.spacedout.data.di.dataModule
 import com.kurnavova.spacedout.domain.di.domainModule
 import com.kurnavova.spacedout.domain.usecase.ScheduleCleanupUseCase
+import com.kurnavova.spacedout.features.favourites.di.favouritesModule
 import com.kurnavova.spacedout.features.newsdetail.di.newsDetailModule
 import com.kurnavova.spacedout.features.newslist.di.newsListModule
 import org.koin.android.ext.android.get
@@ -29,7 +30,7 @@ class App : Application(){
                 androidLogger(Level.DEBUG)
             }
             androidContext(this@App)
-            modules(dataModule, domainModule, newsDetailModule, newsListModule)
+            modules(dataModule, domainModule, newsDetailModule, newsListModule, favouritesModule)
 
             scheduleCleanup()
         }

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/ArticleRemoteMediator.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/ArticleRemoteMediator.kt
@@ -97,7 +97,7 @@ internal class ArticleRemoteMediator(
     private suspend fun cacheArticles(articles: List<ArticleResponse>) {
         withContext(Dispatchers.IO) {
             Log.d(TAG, "Caching articles of size: ${articles.size}")
-            articleDao.insertArticles(articles.map { it.toEntity() })
+            articleDao.upsertArticles(articles.map { it.toEntity() })
         }
     }
 

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/SpaceFlightRepositoryImpl.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/SpaceFlightRepositoryImpl.kt
@@ -45,6 +45,13 @@ internal class SpaceFlightRepositoryImpl(
         pagingData.map { it.toDomain() }
     }
 
+    override fun getFavouriteArticlesWithPaging(): Flow<PagingData<ArticleDetail>> = Pager(
+        config = PagingConfig(pageSize = PAGE_SIZE),
+        pagingSourceFactory = { articleDao.getPagedFavouriteArticles() }
+    ).flow.map { pagingData ->
+        pagingData.map { it.toDomain() }
+    }
+
     override suspend fun getArticleById(id: Int): ApiResult<ArticleDetail> =
         queryArticleFromCache(id)
             ?.let { ApiResult.Success(it.toDomain()) }
@@ -52,6 +59,20 @@ internal class SpaceFlightRepositoryImpl(
                 query = { spaceFlightApi.getArticle(id) },
                 processBody = { it.toDomain() }
             )
+
+    /**
+     * Updates the favourite status of an article by its ID.
+     *
+     * @param id Unique identifier of the article to be updated.
+     * @param isFavourite New favourite status (true or false).
+     */
+    override suspend fun updateFavouriteStatus(id: Int, isFavourite: Boolean) {
+        withContext(dispatcher) {
+            Log.d(TAG, "Updating favourite status of article with id $id to $isFavourite")
+            // Note: For simplicity, let's ignore the result here.
+            runCatching { articleDao.updateFavouriteStatus(id, isFavourite) }
+        }
+    }
 
     /**
      * Cleans the cache by deleting all articles that are older than [CLEANUP_THRESHOLD_DAYS] days.

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/ArticleDao.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/ArticleDao.kt
@@ -16,6 +16,12 @@ internal interface ArticleDao {
     fun getPagedArticles(): PagingSource<Int, ArticleEntity>
 
     /**
+     * Returns a [PagingSource] of favorite articles.
+     */
+    @Query("SELECT * FROM articles WHERE isFavourite = 1 ORDER BY date DESC")
+    fun getPagedFavouriteArticles(): PagingSource<Int, ArticleEntity>
+
+    /**
      * Returns an article by its identifier.
      *
      * @param id Unique identifier.
@@ -28,14 +34,53 @@ internal interface ArticleDao {
      *
      * @param thresholdDate Date in ISO 8601 format.
      */
-    @Query("DELETE FROM articles WHERE date < :thresholdDate")
+    @Query("DELETE FROM articles WHERE date < :thresholdDate AND isFavourite = 0")
     suspend fun deleteOlderThan(thresholdDate: String)
+
+    /**
+     * Updates the isFavourite flag of an article.
+     *
+     * @param id Unique identifier.
+     * @param isFavourite New value of the isFavourite flag.
+     */
+    @Query("UPDATE articles SET isFavourite = :isFavourite WHERE id = :id")
+    suspend fun updateFavouriteStatus(id: Int, isFavourite: Boolean)
 
     /**
      * Inserts articles into the database. Will replace on conflict.
      *
      * @param articles List of articles.
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertArticles(articles: List<ArticleEntity>)
+
+    /**
+     * Upserts articles to database, maintaining their isFavourite flag.
+     *
+     * @param articles List of articles.
+     */
+    @Transaction
+    suspend fun upsertArticles(articles: List<ArticleEntity>) {
+        // Update existing articles to retain their isFavourite flag
+        articles.forEach { article ->
+            updateArticle(article.id, article.title, article.summary, article.url, article.imageUrl, article.author, article.date)
+        }
+
+        // Insert new articles
+        insertArticles(articles)
+    }
+
+    /**
+     * Updates an article in the database except for isFavourite flag.
+     */
+    @Query("UPDATE articles SET title = :title, summary = :summary, url = :url, imageUrl = :imageUrl, author = :author, date = :date WHERE id = :id")
+    suspend fun updateArticle(
+        id: Int,
+        title: String,
+        summary: String,
+        url: String,
+        imageUrl: String,
+        author: List<String>,
+        date: String
+    )
 }

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/mapper/ArticleMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/mapper/ArticleMapper.kt
@@ -14,6 +14,7 @@ internal fun ArticleEntity.toDomain(): ArticleDetail {
         imageUrl = imageUrl,
         url = url,
         authors = author,
-        publishedAt = date
+        publishedAt = date,
+        isFavourite = isFavourite
     )
 }

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/model/ArticleEntity.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/local/model/ArticleEntity.kt
@@ -24,7 +24,8 @@ internal data class ArticleEntity(
     val url: String,
     val imageUrl: String,
     val author: List<String>,
-    val date: String
+    val date: String,
+    val isFavourite: Boolean = false
 )
 
 private const val TABLE_NAME = "articles"

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/mapper/ArticleResponseMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/mapper/ArticleResponseMapper.kt
@@ -14,6 +14,6 @@ internal fun ArticleResponse.toEntity(): ArticleEntity {
         url = url,
         summary = summary,
         author = authors.map { it.name },
-        date = publishedAt
+        date = publishedAt,
     )
 }

--- a/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/network/mapper/ArticleDetailMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/data/spaceflights/network/mapper/ArticleDetailMapper.kt
@@ -14,6 +14,7 @@ internal fun ArticleResponse.toDomain(): ArticleDetail {
         imageUrl = imageUrl,
         url = url,
         authors = authors.map { it.name }, // Extracts only author names
-        publishedAt = publishedAt
+        publishedAt = publishedAt,
+        isFavourite = false
     )
 }

--- a/app/src/main/java/com/kurnavova/spacedout/domain/api/SpaceFlightRepository.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/api/SpaceFlightRepository.kt
@@ -16,6 +16,19 @@ interface SpaceFlightRepository {
     fun getArticlesWithPaging(): Flow<PagingData<ArticleDetail>>
 
     /**
+     * Returns a [Flow] of paginated favorite articles.
+     */
+    fun getFavouriteArticlesWithPaging(): Flow<PagingData<ArticleDetail>>
+
+    /**
+     * Updates the favourite status of an article.
+     *
+     * @param id The unique identifier of the article.
+     * @param isFavourite The new value of the favourite status.
+     */
+    suspend fun updateFavouriteStatus(id: Int, isFavourite: Boolean)
+
+    /**
      * Returns an article by its unique identifier.
      *
      * @param id The unique identifier of the article.

--- a/app/src/main/java/com/kurnavova/spacedout/domain/di/DomainModule.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/di/DomainModule.kt
@@ -3,6 +3,9 @@ package com.kurnavova.spacedout.domain.di
 import com.kurnavova.spacedout.domain.usecase.FetchArticleDetailUseCase
 import com.kurnavova.spacedout.domain.usecase.FetchArticlesUseCase
 import com.kurnavova.spacedout.domain.usecase.ScheduleCleanupUseCase
+import com.kurnavova.spacedout.domain.usecase.UpdateFavouriteStatusUseCase
+import com.kurnavova.spacedout.domain.usecase.FetchFavouriteArticlesUseCase
+
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
@@ -14,4 +17,6 @@ internal val domainModule = module {
     factoryOf(::FetchArticlesUseCase)
     factoryOf(::FetchArticleDetailUseCase)
     factoryOf(::ScheduleCleanupUseCase)
+    factoryOf(::UpdateFavouriteStatusUseCase)
+    factoryOf(::FetchFavouriteArticlesUseCase)
 }

--- a/app/src/main/java/com/kurnavova/spacedout/domain/model/ArticleDetail.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/model/ArticleDetail.kt
@@ -10,6 +10,7 @@ package com.kurnavova.spacedout.domain.model
  * @property url The URL of the article.
  * @property authors The authors of the article.
  * @property publishedAt The date the article was published.
+ * @property isFavourite Whether the article is marked as favourite.
  */
 data class ArticleDetail(
     val id: Int,
@@ -18,5 +19,6 @@ data class ArticleDetail(
     val imageUrl: String,
     val url: String,
     val authors: List<String>,
-    val publishedAt: String
+    val publishedAt: String,
+    val isFavourite: Boolean,
 )

--- a/app/src/main/java/com/kurnavova/spacedout/domain/usecase/FetchFavouriteArticlesUseCase.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/usecase/FetchFavouriteArticlesUseCase.kt
@@ -1,0 +1,20 @@
+package com.kurnavova.spacedout.domain.usecase
+
+import androidx.paging.PagingData
+import com.kurnavova.spacedout.domain.api.SpaceFlightRepository
+import com.kurnavova.spacedout.domain.model.ArticleDetail
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Use case for fetching paginated favourite articles.
+ */
+class FetchFavouriteArticlesUseCase(
+    private val repository:
+    SpaceFlightRepository,
+) {
+    /**
+     * Fetches all favourite articles with paging.
+     */
+    fun invoke(): Flow<PagingData<ArticleDetail>> =
+        repository.getFavouriteArticlesWithPaging()
+}

--- a/app/src/main/java/com/kurnavova/spacedout/domain/usecase/UpdateFavouriteStatusUseCase.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/domain/usecase/UpdateFavouriteStatusUseCase.kt
@@ -1,0 +1,19 @@
+package com.kurnavova.spacedout.domain.usecase
+
+import com.kurnavova.spacedout.domain.api.SpaceFlightRepository
+
+/**
+ * Use case for updating the favourite status of an article.
+ */
+class UpdateFavouriteStatusUseCase(
+    private val repository: SpaceFlightRepository,
+) {
+    /**
+     * Updates the favourite status of an article by its ID.
+     *
+     * @param id Unique identifier of the article.
+     * @param isFavourite New favourite status (true or false).
+     */
+    suspend fun invoke(id: Int, isFavourite: Boolean): Unit =
+        repository.updateFavouriteStatus(id, isFavourite)
+}

--- a/app/src/main/java/com/kurnavova/spacedout/features/favourites/di/FavouritesModule.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/favourites/di/FavouritesModule.kt
@@ -1,0 +1,12 @@
+package com.kurnavova.spacedout.features.favourites.di
+
+import com.kurnavova.spacedout.features.favourites.ui.FavouriteArticlesViewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.dsl.module
+
+/**
+ * Module for the favourites feature.
+ */
+val favouritesModule = module {
+    viewModelOf(::FavouriteArticlesViewModel)
+}

--- a/app/src/main/java/com/kurnavova/spacedout/features/favourites/ui/FavouriteArticlesScreen.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/favourites/ui/FavouriteArticlesScreen.kt
@@ -1,0 +1,129 @@
+package com.kurnavova.spacedout.features.favourites.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.kurnavova.spacedout.R
+import com.kurnavova.spacedout.features.ui.components.ErrorState
+import com.kurnavova.spacedout.features.newslist.ui.components.ListArticle
+import com.kurnavova.spacedout.features.ui.model.Article
+import com.kurnavova.spacedout.ui.preview.ComponentPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun FavouriteArticlesScreenRoot(
+    viewModel: FavouriteArticlesViewModel = koinViewModel(),
+    navigateToDetail: (Int) -> Unit,
+) {
+    FavouriteArticlesScreen(
+        articles = viewModel.uiState.collectAsLazyPagingItems(),
+        onAction = { action ->
+            when (action) {
+                is FavouriteAction.ShowDetail -> navigateToDetail(action.id)
+            }
+        }
+    )
+}
+
+@Composable
+private fun FavouriteArticlesScreen(
+    articles: LazyPagingItems<Article>,
+    onAction: (FavouriteAction) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = SCREEN_PADDING.dp)
+    ) {
+        // Show loading indicator when data is being fetched
+        if (articles.loadState.refresh is LoadState.Loading) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = SPACE_BETWEEN_ITEMS.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+        }
+
+        if (articles.loadState.refresh is LoadState.Error) {
+            ErrorState(
+                message = stringResource(R.string.favourites_load_failed),
+                retry = { articles.refresh() },
+                modifier = Modifier
+                    .padding(vertical = SPACE_BETWEEN_ITEMS.dp)
+                    .fillMaxWidth()
+            )
+        }
+
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(SPACE_BETWEEN_ARTICLES.dp)) {
+            items(articles.itemCount) { index ->
+                articles[index]?.let {
+                    key(it.id) { // Key so that UI remembers expanded state of card for the article, not position.
+                        ListArticle(
+                            article = it,
+                            showDetail = { onAction(FavouriteAction.ShowDetail(it.id)) }
+                        )
+                    }
+                }
+            }
+        }
+
+        // If no articles are available, show  message
+        if (articles.itemCount == 0 && articles.loadState.refresh is LoadState.NotLoading) {
+            Text(
+                text = stringResource(R.string.favourites_no_articles),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = SPACE_BETWEEN_ITEMS.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+        }
+    }
+}
+
+private const val SCREEN_PADDING = 12
+private const val SPACE_BETWEEN_ITEMS = 8
+private const val SPACE_BETWEEN_ARTICLES = 8
+
+@ComponentPreview
+@Composable
+private fun FavouriteArticlesScreenPreview() {
+    val article = Article(
+        id = 1,
+        title = "Article title",
+        summary = "Article summary",
+        imageUrl = "https://example.com/image.jpg",
+        url = "https://example.com",
+        authors = "Author 1, Author 2",
+        publishedAt = "02/03/1992",
+        isFavourite = false
+    )
+
+    val articles = MutableStateFlow(PagingData.from(List(3) { article.copy(id = it) }))
+        .collectAsLazyPagingItems()
+
+    FavouriteArticlesScreen(
+        articles = articles,
+        onAction = {}
+    )
+}

--- a/app/src/main/java/com/kurnavova/spacedout/features/favourites/ui/FavouriteArticlesViewModel.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/favourites/ui/FavouriteArticlesViewModel.kt
@@ -1,0 +1,41 @@
+package com.kurnavova.spacedout.features.favourites.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.kurnavova.spacedout.domain.usecase.FetchFavouriteArticlesUseCase
+import com.kurnavova.spacedout.features.ui.mapper.toArticle
+import com.kurnavova.spacedout.features.ui.model.Article
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * ViewModel for the FavouriteArticlesScreen.
+ */
+class FavouriteArticlesViewModel(
+    fetchFavouriteArticlesUseCase: FetchFavouriteArticlesUseCase
+) : ViewModel() {
+
+    /**
+     * Flow of the current UI state.
+     */
+    val uiState: Flow<PagingData<Article>> = fetchFavouriteArticlesUseCase
+        .invoke().map {
+            it.map { articleDetail -> articleDetail.toArticle() }
+        }
+        .cachedIn(viewModelScope)
+}
+
+/**
+ * Represents an action that can be performed on the FavouriteArticlesScreen.
+ */
+sealed class FavouriteAction {
+    /**
+     * Show the detail screen of an article.
+     *
+     * @param id The ID of the article to show.
+     */
+    data class ShowDetail(val id: Int) : FavouriteAction()
+}

--- a/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/NewsDetailScreen.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/NewsDetailScreen.kt
@@ -32,13 +32,20 @@ fun NewsDetailScreenRoot(
     }
 
     NewsDetailScreen(
-        uiState = viewModel.uiState.collectAsStateWithLifecycle()
+        uiState = viewModel.uiState.collectAsStateWithLifecycle(),
+        onAction = {
+            when (it) {
+                is NewsDetailAction.SetFavourite -> viewModel.onAction(it)
+                else -> Unit
+            }
+        }
     )
 }
 
 @Composable
 private fun NewsDetailScreen(
     uiState: State<NewsDetailUiState>,
+    onAction: (NewsDetailAction) -> Unit
 ) {
     val status = uiState.value
 
@@ -60,8 +67,13 @@ private fun NewsDetailScreen(
                 color = MaterialTheme.colorScheme.error,
                 modifier = Modifier.align(Alignment.Center)
             )
+
             is NewsDetailUiState.Loaded ->
-                ArticleDetail(status.article)
+                ArticleDetail(
+                    status.article, onFavourite = {
+                        onAction(NewsDetailAction.SetFavourite(status.article.id, it))
+                    }
+                )
         }
     }
 }
@@ -81,7 +93,8 @@ private fun NewsDetailScreenPreview() {
                     imageUrl = "https://www.nasa.gov/wp-content/uploads/2025/03/lrc-2025-ocio-p-00643-3.jpg",
                     url = "http://example.com",
                     authors = "Author 1, Author 2",
-                    publishedAt = "02/03/1992"
+                    publishedAt = "02/03/1992",
+                    isFavourite = true
                 )
             )
         )
@@ -90,6 +103,7 @@ private fun NewsDetailScreenPreview() {
     SpacedOutTheme {
         NewsDetailScreen(
             uiState = state,
+            onAction = {}
         )
     }
 }

--- a/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/components/ArticleDetail.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newsdetail/ui/components/ArticleDetail.kt
@@ -1,6 +1,8 @@
 package com.kurnavova.spacedout.features.newsdetail.ui.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,6 +20,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.kurnavova.spacedout.R
 import com.kurnavova.spacedout.features.ui.model.Article
+import com.kurnavova.spacedout.ui.components.button.FavouriteButton
 import com.kurnavova.spacedout.ui.components.image.CoilImage
 import com.kurnavova.spacedout.ui.components.text.ClickableText
 import com.kurnavova.spacedout.ui.components.text.HighlightedText
@@ -29,6 +32,7 @@ import com.kurnavova.spacedout.ui.utils.BrowserUtils
 @Composable
 fun ArticleDetail(
     article: Article,
+    onFavourite: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -48,14 +52,26 @@ fun ArticleDetail(
             modifier = Modifier.fillMaxWidth()
         )
 
-        FadedSubtitle(
-            text = stringResource(
-                R.string.news_detail_authors_datetime,
-                article.authors,
-                article.publishedAt
-            ),
-            modifier = Modifier.padding(vertical = AUTHOR_PADDING.dp)
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = AUTHOR_PADDING.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            FadedSubtitle(
+                text = stringResource(
+                    R.string.news_detail_authors_datetime,
+                    article.authors,
+                    article.publishedAt
+                )
+            )
+            FavouriteButton(
+                isChecked = article.isFavourite,
+                onCheck = onFavourite,
+                modifier = Modifier.align(Alignment.CenterVertically)
+            )
+        }
 
         Spacer(modifier = Modifier.height(SPACE_BETWEEN_ITEMS.dp))
 
@@ -93,8 +109,10 @@ private fun ArticleDetailPreview() {
                 imageUrl = "https://example.com/image.jpg",
                 authors = "Author",
                 publishedAt = "2022-01-01",
-                url = "https://example.com"
-            )
+                url = "https://example.com",
+                isFavourite = false
+            ),
+            onFavourite = {}
         )
     }
 }

--- a/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/NewsListScreen.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/NewsListScreen.kt
@@ -21,7 +21,7 @@ import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.kurnavova.spacedout.R
 import com.kurnavova.spacedout.features.ui.model.Article
-import com.kurnavova.spacedout.features.newslist.ui.components.ErrorState
+import com.kurnavova.spacedout.features.ui.components.ErrorState
 import com.kurnavova.spacedout.features.newslist.ui.components.ListArticle
 import com.kurnavova.spacedout.features.newslist.ui.components.OfflineBanner
 import com.kurnavova.spacedout.features.newslist.ui.utils.isAppendError
@@ -160,7 +160,8 @@ private fun NewsListPreview() {
         imageUrl = "https://example.com/image.jpg",
         url = "https://example.com",
         authors = "Author 1, Author 2",
-        publishedAt = "02/03/1992"
+        publishedAt = "02/03/1992",
+        isFavourite = false
     )
 
     val articles = MutableStateFlow(PagingData.from(List(3) { article.copy(id = it) }))

--- a/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/components/ListArticle.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/newslist/ui/components/ListArticle.kt
@@ -34,7 +34,8 @@ private fun ListArticlePreview() {
                 imageUrl = "https://www.nasa.gov/wp-content/uploads/2025/03/lrc-2025-ocio-p-00643-3.jpg",
                 url = "http://example.com",
                 authors = "Author 1, Author 2",
-                publishedAt = "02/03/1992"
+                publishedAt = "02/03/1992",
+                isFavourite = true
             ),
             showDetail = {}
         )

--- a/app/src/main/java/com/kurnavova/spacedout/features/ui/components/ErrorState.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/ui/components/ErrorState.kt
@@ -1,4 +1,4 @@
-package com.kurnavova.spacedout.features.newslist.ui.components
+package com.kurnavova.spacedout.features.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/app/src/main/java/com/kurnavova/spacedout/features/ui/mapper/ArticleMapper.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/ui/mapper/ArticleMapper.kt
@@ -18,7 +18,8 @@ internal fun ArticleDetail.toArticle(): Article = Article(
     imageUrl = imageUrl,
     url = url,
     authors = authors.joinToString(", "), // For simplicity, let's do this here (should be done in ui layer thought)
-    publishedAt = formatDateTime(publishedAt)
+    publishedAt = formatDateTime(publishedAt),
+    isFavourite = isFavourite
 )
 
 private fun formatDateTime(isoDateTime: String, locale: Locale = Locale.getDefault()): String {

--- a/app/src/main/java/com/kurnavova/spacedout/features/ui/model/Article.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/features/ui/model/Article.kt
@@ -10,6 +10,7 @@ package com.kurnavova.spacedout.features.ui.model
  * @property url The URL of the article.
  * @property authors The authors of the article.
  * @property publishedAt The date when the article was published.
+ * @property isFavourite Whether the article is marked as favourite.
  */
 data class Article(
     val id: Int,
@@ -19,4 +20,5 @@ data class Article(
     val url: String,
     val authors: String,
     val publishedAt: String,
+    val isFavourite: Boolean,
 )

--- a/app/src/main/java/com/kurnavova/spacedout/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/navigation/MainNavHost.kt
@@ -15,8 +15,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.kurnavova.spacedout.R
+import com.kurnavova.spacedout.features.favourites.ui.FavouriteArticlesScreenRoot
 import com.kurnavova.spacedout.features.newsdetail.ui.NewsDetailScreenRoot
 import com.kurnavova.spacedout.features.newslist.ui.NewsListScreenRoot
+import com.kurnavova.spacedout.navigation.route.Favourites
 import com.kurnavova.spacedout.navigation.route.NewsDetail
 import com.kurnavova.spacedout.navigation.route.NewsList
 
@@ -25,7 +27,7 @@ fun MainNavHost(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
 
     var toolbarState: ToolbarState by remember {
-        mutableStateOf(ToolbarState(R.string.app_name, false))
+        mutableStateOf(ToolbarState(R.string.app_name, false, false))
     }
 
     Scaffold(
@@ -33,6 +35,7 @@ fun MainNavHost(modifier: Modifier = Modifier) {
         topBar = {
             Toolbar(
                 toolbarState = toolbarState,
+                goToFavourites = { navController.navigate(Favourites) },
                 popBackStack = navController::popBackStack
             )
         },
@@ -46,7 +49,8 @@ fun MainNavHost(modifier: Modifier = Modifier) {
                 LaunchedEffect(Unit) {
                     toolbarState = ToolbarState(
                         title = R.string.app_name,
-                        backActionAvailable = false
+                        backActionAvailable = false,
+                        showFavourites = true
                     )
                 }
 
@@ -58,12 +62,26 @@ fun MainNavHost(modifier: Modifier = Modifier) {
                 LaunchedEffect(Unit) {
                     toolbarState = ToolbarState(
                         title = R.string.news_detail_toolbar_title,
-                        backActionAvailable = true
+                        backActionAvailable = true,
+                        showFavourites = false
                     )
                 }
 
                 val route = backStackEntry.toRoute<NewsDetail>()
                 NewsDetailScreenRoot(id = route.id)
+            }
+            composable<Favourites> {
+                LaunchedEffect(Unit) {
+                    toolbarState = ToolbarState(
+                        title = R.string.favourites_toolbar_title,
+                        backActionAvailable = true,
+                        showFavourites = false
+                    )
+                }
+
+                FavouriteArticlesScreenRoot(
+                    navigateToDetail = {  navController.navigate(NewsDetail(it)) }
+                )
             }
         }
     }

--- a/app/src/main/java/com/kurnavova/spacedout/navigation/Toolbar.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/navigation/Toolbar.kt
@@ -3,6 +3,7 @@ package com.kurnavova.spacedout.navigation
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -20,6 +21,7 @@ import com.kurnavova.spacedout.ui.theme.SpacedOutTheme
 @Composable
 fun Toolbar(
     toolbarState: ToolbarState,
+    goToFavourites: () -> Unit,
     popBackStack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -31,6 +33,16 @@ fun Toolbar(
                     Icon(
                         Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = stringResource(R.string.back)
+                    )
+                }
+            }
+        },
+        actions = {
+            if (toolbarState.showFavourites) {
+                IconButton(onClick = goToFavourites) {
+                    Icon(
+                        Icons.Default.FavoriteBorder,
+                        contentDescription = stringResource(R.string.favourites_toolbar_title)
                     )
                 }
             }
@@ -49,7 +61,8 @@ fun Toolbar(
 data class ToolbarState(
     @StringRes
     val title: Int,
-    val backActionAvailable: Boolean
+    val backActionAvailable: Boolean,
+    val showFavourites: Boolean
 )
 
 @ComponentPreview
@@ -57,7 +70,8 @@ data class ToolbarState(
 private fun ToolbarPreview() {
     SpacedOutTheme {
         Toolbar(
-            toolbarState = ToolbarState(R.string.app_name, false),
+            toolbarState = ToolbarState(R.string.app_name, false, true),
+            goToFavourites = {},
             popBackStack = {}
         )
     }

--- a/app/src/main/java/com/kurnavova/spacedout/navigation/route/NavRoute.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/navigation/route/NavRoute.kt
@@ -20,3 +20,9 @@ data object NewsList : NavRoute
  */
 @Serializable
 data class NewsDetail(val id: Int) : NavRoute
+
+/**
+ * Favourites route.
+ */
+@Serializable
+data object Favourites : NavRoute

--- a/app/src/main/java/com/kurnavova/spacedout/ui/components/button/FavouriteButton.kt
+++ b/app/src/main/java/com/kurnavova/spacedout/ui/components/button/FavouriteButton.kt
@@ -1,0 +1,52 @@
+package com.kurnavova.spacedout.ui.components.button
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.kurnavova.spacedout.R
+import com.kurnavova.spacedout.ui.preview.ComponentPreview
+
+@Composable
+fun FavouriteButton(
+    isChecked: Boolean,
+    onCheck: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    IconButton(
+        onClick = {
+            onCheck(!isChecked)
+        },
+        modifier = modifier
+    ) {
+        Icon(
+            imageVector = if (isChecked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+            contentDescription = if (isChecked) {
+                stringResource(R.string.favourite_button_remove_descr)
+            } else {
+                stringResource(R.string.favourite_button_add_descr)
+            },
+            tint = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+fun FavouriteButtonPreview() {
+    var isFavourite by remember { mutableStateOf(false) }
+
+    FavouriteButton(
+        isChecked = isFavourite,
+        onCheck = { isFavourite = it },
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,17 @@
     <!-- Offline message on news list screen. -->
     <string name="offline_message">Showing offline data only!</string>
 
+    <!-- Favourite articles screen -->
+    <!-- Toolbar title for favourite articles screen. -->
+    <string name="favourites_toolbar_title">Favourites</string>
+    <!-- Message for empty favourite articles list. -->
+    <string name="favourites_no_articles">You have no favourite articles</string>
+    <!-- Loading error message. -->
+    <string name="favourites_load_failed">There was an error loading your favourite articles.</string>
+
+    <!-- Favourite button -->
+    <!-- Favourite button content description for removing -->
+    <string name="favourite_button_remove_descr">Remove from favourites</string>
+    <!-- Favourite button content description for adding -->
+    <string name="favourite_button_add_descr">Add to favourites</string>
 </resources>


### PR DESCRIPTION
**Favourites Feature:**
- Users can mark an article as a favourite by tapping the heart icon in the article detail.
- Favourite articles are always stored in the database and are never deleted.
- The list of favourite articles is displayed when the heart icon in the toolbar is tapped.

**Possible Future Improvements (Out of Scope):**
- Indicate whether an item is a favourite in the list, and potentially allow marking an item as a favourite directly from the list.
- Add an option to navigate to the favourites list from the article detail.
- Implement error messaging/handling in case marking an item as a favourite fails.
- Add unit tests to cover the newly added DAO methods.


**ChatGPT prompts used to implement the feature:**

- [DAO + Entity code - containing new attribute "isFavourite"] Add method returning pagingSource for all favourite articles (isFavourite is true), sorted same as all articles.

- Exclude all favourites from deleteOlderThan - we are always keeping favorite stored.

- I need to rewrite insertArticles in a way so that it will maintain isFavourite flag of entity if the item already exists. Make it as efficient as you can, least looping possible.

- Generate me dao method to update isFavourite flag of entity.

- Add method for paged favourite articles to repository [code] similar to [getArticlesWithPaging code].

- Generate 2 usecases - one to update the flag, another to fetch favourite paging data. Use same structure as [code of FetchArticlesUseCase].

- Generate me "favourite" button as separate Composable with Preview - clickable heart icon (compose icons) taking isChecked as parameter which will denote state of whether the heart is overlined or filled. Another parameter onCheck callback which takes true/false as parameter. Make it as general as possible.

- Use it then in ArticleDetail  [code] - align it with FadedSubtitle on the far right side with article.isFavourite denoting its isChecked state.

- Generate me Favourite articles screen in compose and its VM using MVI:
-- VM: will expose paging data flow from usecase FetchFavouriteArticlesUseCase,
-- Under VM put sealed class with FavouriteAction containing showing detail of article.
-- UI: Root composable taking ViewModel and navigateToDetail. 
-- Screen composable taking LazyPagingItems and onAction as params. Make UI similar to NewsList [code]. There will be just one simple error state - when list is empty, show string “You have no favourite articles” (give me string definition). There will be loading before items are shown. No refresh. Reuse ListArticle component for showing list item. Add Preview.
-- Make it all consistent with following. [code for list VM and Screen]

